### PR TITLE
Fix CAPS_LED logic in Satan (#461)

### DIFF
--- a/keyboards/satan/satan.c
+++ b/keyboards/satan/satan.c
@@ -22,9 +22,9 @@ void led_init_ports(void) {
 void led_set_kb(uint8_t usb_led) {
     if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
         // Turn capslock on
-        PORTB |= (1<<2);
+        PORTB &= ~(1<<2);
     } else {
         // Turn capslock off
-        PORTB &= ~(1<<2);
+        PORTB |= (1<<2);
     }
 }


### PR DESCRIPTION
Needed to invert for proper operation. Previous code had LED on when off
and vice versa.